### PR TITLE
Updated xbps_repoconf_repos checks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,7 @@
     owner: root
     group: root
     mode: 0644
-  when: xbps_repoconf_repos
+  when: xbps_repoconf_repos is defined
   with_items: "{{ xbps_repoconf_repos }}"
 
 - name: Configure additional repository fingerprints
@@ -47,7 +47,7 @@
     owner: root
     group: root
     mode: 0644
-  when: xbps_repoconf_repos
+  when: xbps_repoconf_repos is defined
   with_items: "{{ xbps_repoconf_repos }}"
 
 - name: Sync XBPS

--- a/templates/xbps.rules
+++ b/templates/xbps.rules
@@ -2,7 +2,7 @@
 -A OUTPUT -p tcp -d {{ xbps_repository_address }} --dport {{ xbps_repository_port }} -j ACCEPT
 COMMIT
 
-{% if xbps_repoconf_repos %}
+{% if xbps_repoconf_repos is defined %}
 *filter
 {% for repo in xbps_repoconf_repos %}
 -A OUTPUT -p tcp -d {{ repo.serveraddr }} --dport {{ repo.serverport }} -j ACCEPT


### PR DESCRIPTION
As xbps_repoconf_repos is an optional list of dictionaries, the check
should see if it is defined, not if it is true.